### PR TITLE
TOOL-11725 drgn: fix python build dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,6 +6,7 @@ Standards-Version: 4.1.2
 Build-Depends: autoconf,
                automake,
                bison,
+               dh-python,
                elfutils,
                flex,
                gawk,
@@ -24,7 +25,7 @@ Build-Depends: autoconf,
                pkg-config,
                python3,
                python3-distutils,
-               python3.6-dev,
+               python3-dev,
                zlib1g-dev
 
 Package: drgn


### PR DESCRIPTION
Prepares drgn for Ubuntu 20.04, which uses a different version of python3 (3.8 vs 3.6).

## Testing
- ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5584/
- Verified drgn builds and works on Ubuntu 20.04