### PR TITLE
DLPX-94107 restore .pre-commit-config.yaml in drgn repo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,43 @@
+exclude: ^contrib/
+repos:
+-   repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+    -   id: isort
+        name: isort (python)
+-   repo: https://github.com/psf/black
+    rev: 24.8.0
+    hooks:
+    -   id: black
+        exclude: ^docs/exts/details\.py$
+-   repo: https://github.com/pycqa/flake8
+    rev: 7.1.1
+    hooks:
+    -   id: flake8
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.11.2
+    hooks:
+    -   id: mypy
+        args: [--show-error-codes, --strict, --no-warn-return-any, --no-warn-unused-ignores]
+        files: ^(drgn/.*\.py|_drgn.pyi|_drgn_util/.*\.py|tools/.*\.py)$
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+    -   id: trailing-whitespace
+        exclude_types: [diff]
+    -   id: end-of-file-fixer
+        exclude_types: [diff]
+    -   id: check-yaml
+    -   id: check-added-large-files
+    -   id: debug-statements
+    -   id: check-merge-conflict
+-   repo: https://github.com/netromdk/vermin
+    rev: v1.6.0
+    hooks:
+    -   id: vermin
+        # The vmtest package in general should adhere to the same version
+        # requirements as drgn, with the following exceptions: The manage &
+        # kbuild scripts are used by Github Actions and need not be broadly
+        # compatible.
+        exclude: "^vmtest/(manage|kbuild).py$"
+        args: ['-t=3.6-', '--violations', '--eval-annotations']


### PR DESCRIPTION
The drgn package has a merge conflict preventing the auto-update because we deleted a file (.pre-commit-config.yaml) that evidently gets modified relatively frequently in an attempt to disable pesky pre-commit tests that get run and fail in the context of pre-commit locally.

In the interest of reducing the overhead of maintaining this package and eliminating sources of merge conflicts, we should restore this file. Developers will have to know to do git review --no-verify to skip pre-commit checks on this repo if they ever have to file PRs in this repo.
