### PR TITLE
TOOL-30782 add python3-setuptools to build deps for resolute

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -25,6 +25,7 @@ Build-Depends: autoconf,
                pkg-config,
                python3,
                python3-dev,
+               python3-setuptools,
                zlib1g-dev
 
 Package: drgn


### PR DESCRIPTION
## Problem

`drgn` fails to build on Ubuntu 26.04 (resolute) in `build-packages/post-push` #5:

```
ModuleNotFoundError: No module named 'setuptools'
dh_auto_clean: error: pybuild --clean -i python{version} -p 3.14 --parallel=2 returned exit code 13
```

Resolute ships Python 3.14, which no longer bundles setuptools; it was reached implicitly on noble's 3.12.

## Solution

The solution is to declare `python3-setuptools` in `Build-Depends`. Same change already landed for `crash-python` ([#12](https://github.com/delphix/crash-python/pull/12)) and `savedump` ([#19](https://github.com/delphix/savedump/pull/19)) for the identical failure.

Note this branch is currently **60 commits behind `develop`** (purely behind, no divergence). Patching in place deliberately, so this known fix isn't conflated with untested drift; the re-reset is worth doing separately. `develop`'s `debian/control` lacks the build-dep too, so the change is needed regardless of which base it lands on.

## Testing Done

Not yet built; validated by the next `build-packages/post-push` `BUILD_POLICY=ALL` run. Results on TOOL-30782.