### PR TITLE
TOOL-30782 declare the python3-setuptools build dep

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -25,6 +25,7 @@ Build-Depends: autoconf,
                pkg-config,
                python3,
                python3-dev,
+               python3-setuptools,
                zlib1g-dev
 
 Package: drgn


### PR DESCRIPTION
## Problem

`setup.py` imports `setuptools` without `debian/control` declaring it, so the build relies on something else pulling it in. That holds on noble (Python 3.12 still ships it) and stops holding on Python 3.14:

```
ModuleNotFoundError: No module named 'setuptools'
dh_auto_clean: error: pybuild --clean -i python{version} -p 3.14 --parallel=2 returned exit code 13
```

## Solution

The solution is to declare it. `python3-setuptools` is present in noble (`68.1.2-2ubuntu1`, verified against the develop mirror), so this is a **no-op on this branch** — it removes the implicit dependency rather than waiting for the cutover to force it.

Already landed on `os-upgrade` ([#77](https://github.com/delphix/drgn/pull/77)), where it is load-bearing. Same change went to `crash-python` and `savedump` for the identical failure. Raising it here so it is one fewer change to re-land at the Ubuntu 26.04 cutover.

## Testing Done

Not separately built on this branch. The identical change builds clean against Python 3.14 on `os-upgrade`, which is the case that exercises it; on noble the dependency was already satisfied implicitly.